### PR TITLE
Fix crash if calling fill_tile or erase_tile on the first frame

### DIFF
--- a/scripts/TileMapDual.gd
+++ b/scripts/TileMapDual.gd
@@ -241,12 +241,19 @@ func _is_world_tile_sketched(_world_cell: Vector2i):
 
 
 ## Public method to add a tile in a given World cell
-func fill_tile(cell, atlas_id=0) -> void:
+func fill_tile(cell: Vector2i, atlas_id: int = 0) -> void:
+	# Prevents a crash if this is called on the first frame
+	if display_tilemap == null:
+		update_full_tileset()
+	
 	set_cell(cell, atlas_id, full_tile)
 	update_tile(cell)
 
 
 ## Public method to erase a tile in a given World cell
-func erase_tile(cell, atlas_id=0) -> void:
+func erase_tile(cell: Vector2i, atlas_id: int = 0) -> void:
+	if display_tilemap == null:
+		update_full_tileset()
+	
 	set_cell(cell, atlas_id, empty_tile)
 	update_tile(cell)


### PR DESCRIPTION
Previously, if `fill_tile` or `erase_tile` was called on the first frame of the scene, it would cause a crash since the display tileset isn't initialized until afterwards. This fixes that. Now, if those methods are called before the display tilemap is created, it calls `update_full_tileset()` to avoid crashing.

Also adds type annotations to those methods, matching the arguments for `set_cell`.